### PR TITLE
Fix cannot fill secondary data to export model

### DIFF
--- a/actions/ExportController.php
+++ b/actions/ExportController.php
@@ -113,7 +113,7 @@ class ExportController extends ControllerAction
 
             $model = $this->getExportModel();
 
-            if ($secondaryData = post('Secondary')) {
+            if ($secondaryData = post('ExportSecondary')) {
                 $model->fill($secondaryData);
             }
 


### PR DESCRIPTION
Due to wrong form name (`ExportSecondary` instead `Secondary`), export model can not be filled with secondary form data. I introduced a commit to fix it, please merge my PR